### PR TITLE
ci: including all samples in pull request check

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -76,6 +76,12 @@ graalvm)
     ;;
 samples)
     SAMPLES_DIR=samples
+    # only run ITs in snapshot/ on presubmit PRs. run ITs in all 3 samples/ subdirectories otherwise.
+    if [[ ! -z ${KOKORO_GITHUB_PULL_REQUEST_NUMBER} ]]
+    then
+      SAMPLES_DIR=samples/snapshot
+    fi
+
     if [[ -f ${SAMPLES_DIR}/pom.xml ]]
     then
         for FILE in ${KOKORO_GFILE_DIR}/secret_manager/*-samples-secrets; do

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -76,12 +76,6 @@ graalvm)
     ;;
 samples)
     SAMPLES_DIR=samples
-    # only run ITs in snapshot/ on presubmit PRs. run ITs in all 3 samples/ subdirectories otherwise.
-    if [[ ! -z ${KOKORO_GITHUB_PULL_REQUEST_NUMBER} ]]
-    then
-      SAMPLES_DIR=samples/snapshot
-    fi
-
     if [[ -f ${SAMPLES_DIR}/pom.xml ]]
     then
         for FILE in ${KOKORO_GFILE_DIR}/secret_manager/*-samples-secrets; do

--- a/README.md
+++ b/README.md
@@ -22,20 +22,20 @@ If you are using Maven, add this to your pom.xml file:
 <dependency>
   <groupId>com.google.analytics</groupId>
   <artifactId>google-analytics-data</artifactId>
-  <version>0.11.5</version>
+  <version>0.11.6</version>
 </dependency>
 ```
 
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.analytics:google-analytics-data:0.11.5'
+implementation 'com.google.analytics:google-analytics-data:0.11.6'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.analytics" % "google-analytics-data" % "0.11.5"
+libraryDependencies += "com.google.analytics" % "google-analytics-data" % "0.11.6"
 ```
 
 ## Authentication

--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -35,7 +35,8 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.6.0</version>
+      <!-- Choose a proper version from https://search.maven.org/artifact/com.google.analytics/google-analytics-data/0.11.4/jar -->
+      <version>1.4.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
For https://github.com/googleapis/java-analytics-data/issues/431, where the nightly build started failing because RenovateBot pull request https://github.com/googleapis/java-analytics-data/pull/448 reverted Mike's fix last week. The checks should run for normal pull requests, not just nightly builds.